### PR TITLE
Add view encoding settings. Set utf-8 encoding as default

### DIFF
--- a/lib/cuba/contrib/rendering.rb
+++ b/lib/cuba/contrib/rendering.rb
@@ -6,6 +6,7 @@ class Cuba
       app.plugin Cuba::Settings
       app.set :template_engine, "erb"
       app.set :views, File.expand_path("views", Dir.pwd)
+      app.set :encoding, Encoding::UTF_8
     end
 
     def view(template, locals = {})
@@ -13,7 +14,7 @@ class Cuba
     end
 
     def partial(template, locals = {})
-      render("#{settings.views}/#{template}.#{settings.template_engine}", locals)
+      render("#{settings.views}/#{template}.#{settings.template_engine}", locals, default_encoding: settings.encoding)
     end
 
     # Render any type of template file supported by Tilt.

--- a/lib/cuba/contrib/rendering.rb
+++ b/lib/cuba/contrib/rendering.rb
@@ -6,7 +6,6 @@ class Cuba
       app.plugin Cuba::Settings
       app.set :template_engine, "erb"
       app.set :views, File.expand_path("views", Dir.pwd)
-      app.set :encoding, Encoding::UTF_8
     end
 
     def view(template, locals = {})
@@ -14,7 +13,7 @@ class Cuba
     end
 
     def partial(template, locals = {})
-      render("#{settings.views}/#{template}.#{settings.template_engine}", locals, default_encoding: settings.encoding)
+      render("#{settings.views}/#{template}.#{settings.template_engine}", locals, default_encoding: Encoding.default_external)
     end
 
     # Render any type of template file supported by Tilt.


### PR DESCRIPTION
A fix @djanowski told me on IRC in order to handle utf8 characters in views without having to declare `#encoding utf-8` every time.
