### PR TITLE
Add mote as a runtime dependency

### DIFF
--- a/cuba-contrib.gemspec
+++ b/cuba-contrib.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "cuba", "~> 3.1"
   s.add_development_dependency "cutest"
-  s.add_development_dependency "mote", "~> 1.0"
+  s.add_dependency "mote", "~> 1.0"
 end


### PR DESCRIPTION
Mote is not a development dependency, as cuba/contrib requires
cuba/mote, which in turn requires mote.
